### PR TITLE
enable to write item's password

### DIFF
--- a/command/write/write.go
+++ b/command/write/write.go
@@ -1,19 +1,29 @@
 package write
 
 import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
 	"github.com/cappyzawa/op-kv/command/util"
 	"github.com/spf13/cobra"
 )
 
 type options struct {
+	outStream io.Writer
+	errStream io.Writer
 }
 
-func NewOptions() *options {
-	return &options{}
+func NewOptions(outStream, errStream io.Writer) *options {
+	return &options{
+		outStream: outStream,
+		errStream: errStream,
+	}
 }
 
 func NewCmdWrite(f util.Factory) *cobra.Command {
-	o := NewOptions()
+	o := NewOptions(os.Stdout, os.Stderr)
 	cmd := &cobra.Command{
 		Use:   "write <item> <password>",
 		Short: "Generate one password by specified item and password",
@@ -25,5 +35,29 @@ func NewCmdWrite(f util.Factory) *cobra.Command {
 }
 
 func (o *options) Run(f util.Factory, cmd *cobra.Command, args []string) error {
+	if len(args) < 2 {
+		cmd.Help()
+		return nil
+	}
+	item := args[0]
+	password := args[1]
+
+	runner := f.CommandRunner()
+
+	opTmpCmd := []string{"op", "get", "template", "login"}
+	jqCmd := []string{"jq", "-c", fmt.Sprintf(".fields[1].value = \"%s\"", password)}
+	opEncCmd := []string{"op", "encode"}
+	output, err := runner.Output(opTmpCmd, jqCmd, opEncCmd)
+	if err != nil {
+		fmt.Fprint(o.errStream, err.Error())
+		return err
+	}
+
+	opCmd := []string{"op", "create", "item", "login", strings.TrimRight(string(output), "\n"), fmt.Sprintf("--title=%s", item)}
+	if _, err := runner.Output(opCmd); err != nil {
+		fmt.Fprint(o.errStream, err.Error())
+		return err
+	}
+	fmt.Fprint(o.outStream, "success to write password!!")
 	return nil
 }

--- a/command/write/write_test.go
+++ b/command/write/write_test.go
@@ -1,0 +1,57 @@
+package write_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cappyzawa/op-kv/command/util/utilfakes"
+	"github.com/cappyzawa/op-kv/command/write"
+	"github.com/cappyzawa/op-kv/op-kvfakes"
+)
+
+func TestOptions_Run(t *testing.T) {
+	cases := []struct {
+		name        string
+		args        []string
+		mockOut     []byte
+		mockErr     error
+		expect      string
+		expectError string
+	}{
+		{name: "ensure StdOut", args: []string{"item", "password"}, mockOut: nil, mockErr: nil, expect: "success to write password!!", expectError: ""},
+		{name: "ensure StdErr when failing to write", args: []string{"item", "password"}, mockOut: nil, mockErr: errors.New("some error"), expect: "", expectError: "some error"},
+	}
+
+	t.Helper()
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			item := c.args[0]
+			password := c.args[1]
+			runner := new(opkvfakes.FakeRunner)
+			f := new(utilfakes.FakeFactory)
+			outStream := new(bytes.Buffer)
+			errStream := new(bytes.Buffer)
+			options := write.NewOptions(outStream, errStream)
+			cmd := write.NewCmdWrite(f)
+			opTmpCmd := []string{"op", "get", "template", "login"}
+			jqCmd := []string{"jq", "-c", fmt.Sprintf(".fields[1].value = \"%s\"", password)}
+			opEncCmd := []string{"op", "encode"}
+			f.CommandRunnerReturns(runner)
+			output, _ := runner.Output(opTmpCmd, jqCmd, opEncCmd)
+			runner.OutputReturns([]byte("encoded"), nil)
+			opCmd := []string{"op", "create", "item", "login", strings.TrimRight(string(output), "\n"), fmt.Sprintf("--title=%s", item)}
+			runner.Output(opCmd)
+			runner.OutputReturns(c.mockOut, c.mockErr)
+			options.Run(f, cmd, c.args)
+			if outStream.String() != c.expect {
+				t.Errorf("%s should be displayed, but actual is %s", c.expect, outStream.String())
+			}
+			if errStream.String() != c.expectError {
+				t.Errorf("%s should be displayed, but actual is %s", c.expectError, errStream.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
enable to use `op-kv write <item> <password>`  instead of below.
```bash
$ D=$(op get template login | jq -c '.fields[1].value = <password>' | op encode)
$ op create item login $D --title=<item>
```