### PR TITLE
fix error handling

### DIFF
--- a/command/read/read.go
+++ b/command/read/read.go
@@ -1,6 +1,7 @@
 package read
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -22,23 +23,18 @@ func NewOptions(outStream, errStream io.Writer) *options {
 }
 
 func NewCmdRead(f util.Factory) *cobra.Command {
-	o := NewOptions(os.Stdout, os.Stderr)
+	o := NewOptions(os.Stdout, new(bytes.Buffer))
 	cmd := &cobra.Command{
 		Use:   "read [<UUID>|<name>]",
 		Short: "Display one password of specified item by UUID or name",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return o.Run(f, cmd, args)
+		Run: func(cmd *cobra.Command, args []string) {
+			o.Run(f, cmd, args)
 		},
 	}
 	return cmd
 }
 
-func (o *options) Run(f util.Factory, cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		cmd.Help()
-		return nil
-	}
-
+func (o *options) Run(f util.Factory, cmd *cobra.Command, args []string) {
 	item := args[0]
 	runner := f.CommandRunner()
 
@@ -49,9 +45,9 @@ func (o *options) Run(f util.Factory, cmd *cobra.Command, args []string) error {
 	output, err := runner.Output(opCmd, jqCmd)
 	if err != nil {
 		fmt.Fprint(o.errStream, err)
-		return err
+		return
 	}
 
 	fmt.Fprintf(o.outStream, "%s", string(output))
-	return nil
+	return
 }


### PR DESCRIPTION
* Before
not currently signed in..
```bash
[LOG] 2019/02/17 01:41:25 (ERROR) You are not currently signed in. Please run `op signin --help` for instructions
hoooooooooooo
 exit status 1
exit status 1Error: exit status 1
Usage:
  op-kv write <item> <password> [flags]

Flags:
  -h, --help   help for write

exit status 1
exit status 1
```

* After
```
[LOG] 2019/02/17 01:46:01 (ERROR) You are not currently signed in. Please run `op signin --help` for instructions
hoooooooooooo
 exit status 1
```

`mattn/go-pipeline`.Output() outputs error to Stderr.